### PR TITLE
Inverter Enable/Disable CLI Command

### DIFF
--- a/vcu/Inc/motorController.h
+++ b/vcu/Inc/motorController.h
@@ -56,5 +56,6 @@ HAL_StatusTypeDef setMotorControllerSettings(MotorControllerSettings settings);
 HAL_StatusTypeDef setDischargeCurrentLimit(float limit);
 HAL_StatusTypeDef setForwardSpeedLimit(float limit);
 HAL_StatusTypeDef setTorqueLimit(float limit);
+HAL_StatusTypeDef sendInverter(bool enable);
 
 #endif /* end of include guard: MOTORCONTROLLER_H */

--- a/vcu/Src/drive_by_wire_mock.c
+++ b/vcu/Src/drive_by_wire_mock.c
@@ -440,6 +440,32 @@ static const CLI_Command_Definition_t mcInitCommandDefinition =
     0 /* Number of parameters */
 };
 
+BaseType_t setInverterCommand(char *writeBuffer, size_t writeBufferLength,
+                       const char *commandString)
+{
+    BaseType_t paramLen;
+    const char * onOffParam = FreeRTOS_CLIGetParameter(commandString, 1, &paramLen);
+
+    bool onOff = false;
+    if (STR_EQ(onOffParam, "on", paramLen)) {
+        onOff = true;
+    } else if (STR_EQ(onOffParam, "off", paramLen)) {
+        onOff = false;
+    } else {
+        COMMAND_OUTPUT("Unknown parameter\n");
+        return pdFALSE;
+    }
+
+    return pdFALSE;
+}
+static const CLI_Command_Definition_t setInverterCommandDefinition =
+{
+    "setInverter",
+    "setInverter <on|off>:\r\n  Sends a CAN command to the PCU to turn on/off the inverter\r\n",
+    setInverterCommand,
+    1 /* Number of parameters */
+};
+
 HAL_StatusTypeDef stateMachineMockInit()
 {
     if (FreeRTOS_CLIRegisterCommand(&throttleABCommandDefinition) != pdPASS) {
@@ -497,6 +523,9 @@ HAL_StatusTypeDef stateMachineMockInit()
         return HAL_ERROR;
     }
     if (FreeRTOS_CLIRegisterCommand(&getSteeringCommandDefinition) != pdPASS) {
+        return HAL_ERROR;
+    }
+    if (FreeRTOS_CLIRegisterCommand(&setInverterCommandDefinition) != pdPASS) {
         return HAL_ERROR;
     }
 

--- a/vcu/Src/drive_by_wire_mock.c
+++ b/vcu/Src/drive_by_wire_mock.c
@@ -456,6 +456,17 @@ BaseType_t setInverterCommand(char *writeBuffer, size_t writeBufferLength,
         return pdFALSE;
     }
 
+    bool hvEnable = getHvEnableState();
+
+    if(hvEnable) {
+        COMMAND_OUTPUT("High Voltage is enabled, command not sent");
+    } else {
+        COMMAND_OUTPUT("Turning inverter %s\n", onOff?"on":"off");
+        if(sendInverter() != HAL_OK) {
+            ERROR_PRINT("Command failed to toggle inverter");
+        }
+    }
+
     return pdFALSE;
 }
 static const CLI_Command_Definition_t setInverterCommandDefinition =

--- a/vcu/Src/motorController.c
+++ b/vcu/Src/motorController.c
@@ -176,3 +176,19 @@ HAL_StatusTypeDef requestTorqueFromMC(float throttle_percent) {
 
     return HAL_OK;
 }
+
+HAL_StatusTypeDef sendInverter(bool enable) {
+    if(enable && fsmGetState(&fsmHandle) == STATE_EM_Enable) {
+        COMMAND_OUTPUT("Inverter is already enabled");
+        return HAL_OK;
+    }
+
+    EM_State = (enable)?EM_State_On:EM_State_Off;
+
+    if (sendCAN_VCU_EM_State() != HAL_OK) {
+        ERROR_PRINT("Failed to send command message to MC\n");
+        return HAL_ERROR;
+    }
+        
+    return HAL_OK;
+}

--- a/vcu/Src/motorController.c
+++ b/vcu/Src/motorController.c
@@ -178,9 +178,22 @@ HAL_StatusTypeDef requestTorqueFromMC(float throttle_percent) {
 }
 
 HAL_StatusTypeDef sendInverter(bool enable) {
+    
+    // ON  command   ON  status   turn off
+    // ON  command   OFF status   turn on
+    // OFF command   ON  status   turn off
+    // OFF command   OFF status   turn off 
+
     if(enable && fsmGetState(&fsmHandle) == STATE_EM_Enable) {
-        COMMAND_OUTPUT("Inverter is already enabled");
-        return HAL_OK;
+        ERROR_PRINT("Unexpected Input: Inverter is already on... Turning off Inverter");
+        
+        EM_State = EM_State_Off;
+        if (sendCAN_VCU_EM_State() != HAL_OK) {
+            ERROR_PRINT("Failed to send command message to MC\n");
+            return HAL_ERROR;
+        }
+        
+        return HAL_ERROR;
     }
 
     EM_State = (enable)?EM_State_On:EM_State_Off;


### PR DESCRIPTION
Added the `setInverter <on|off>` command to the VCU
It will only turn the inverter on if HV is off and the inverter is off, else it will turn the inverter off.