### PR TITLE
Add BMU fan manual override via Cooling CAN signal

### DIFF
--- a/bmu/Inc/fanControl.h
+++ b/bmu/Inc/fanControl.h
@@ -2,6 +2,11 @@
 
 #define FANCONTROL_H
 
+#include "stdbool.h"
 
+void setManualFanOverride(bool override);
+HAL_StatusTypeDef fanInit();
+HAL_StatusTypeDef setFan();
+void fanTask();
 
 #endif /* end of include guard: FANCONTROL_H */

--- a/bmu/Src/canReceive.c
+++ b/bmu/Src/canReceive.c
@@ -15,6 +15,7 @@
 #include "debug.h"
 #include "boardTypes.h"
 #include "batteries.h"
+#include "fanControl.h"
 
 #include "controlStateMachine.h"
 
@@ -35,6 +36,11 @@ void CAN_Msg_VCU_buttonEvents_Callback()
     if (ButtonHVEnabled) {
 		DEBUG_PRINT_ISR("HV Toggle button event\n");
         fsmSendEventISR(&fsmHandle, EV_HV_Toggle);
+    }
+    if(Cooling){
+        static bool fanState = false;
+        fanState = !fanState;
+        setManualFanOverride(fanState);
     }
 }
 

--- a/bmu/Src/fanControl.c
+++ b/bmu/Src/fanControl.c
@@ -26,6 +26,13 @@
 #define FAN_PERIOD_COUNT 400
 #define FAN_TASK_PERIOD_MS 1000
 
+//introducing the manualOveride feature
+static bool manualFanOverride = false;
+
+void setManualFanOverride(bool overide){
+  manualFanOverride = overide;
+}
+
 uint32_t calculateFanPeriod()
 {
   // PWM Output is inverted from what we generate from PROC
@@ -60,6 +67,10 @@ HAL_StatusTypeDef fanInit()
 HAL_StatusTypeDef setFan()
 {
   uint32_t duty = calculateFanPeriod();
+
+  if(manualFanOverride){
+    duty = 0; //Overide. Fans go FULL BLAST (inverted PWM)
+  }
 
   __HAL_TIM_SET_COMPARE(&FAN_HANDLE, TIM_CHANNEL_1, duty);
   

--- a/common/Data/2024CAR.dbc
+++ b/common/Data/2024CAR.dbc
@@ -915,6 +915,7 @@ BO_ 2550137362 TempCoolantLeft: 8 WSBRL
  SG_ TempInletRadMotorLeft : 0|10@1- (0.25,90) [-38|217.75] "C"  VCU_BeagleBone,VCU_F7
 
 BO_ 2214662151 VCU_buttonEvents: 8 VCU_F7
+ SG_ Cooling : 7|1@1+ (1,0) [0|0] "bool"  BMU,PDU
  SG_ ButtonScreenNavLeftEnabled : 6|1@1+ (1,0) [0|0] "bool"  VCU_BeagleBone
  SG_ ButtonScreenNavRightEnabled : 5|1@1+ (1,0) [0|0] "bool"  VCU_BeagleBone
  SG_ ButtonEnduranceToggleEnabled : 4|1@1+ (1,0) [0|0] "bool"  VCU_BeagleBone
@@ -922,6 +923,7 @@ BO_ 2214662151 VCU_buttonEvents: 8 VCU_F7
  SG_ ButtonTCEnabled : 2|1@1+ (1,0) [0|0] "bool"  VCU_BeagleBone
  SG_ ButtonHVEnabled : 1|1@1+ (1,0) [0|0] "bool"  BMU,VCU_BeagleBone
  SG_ ButtonEMEnabled : 0|1@1+ (1,0) [0|0] "bool"  VCU_BeagleBone
+
 
 BO_ 2550141444 ChargeCart_VERSION: 8 ChargeCart
  SG_ ChargeCart_Version_DB : 0|8@1- (1,0) [0|0] ""  VCU_BeagleBone


### PR DESCRIPTION
Overrides the cooling on command of the button press. Should match with the Cooling-button-feature logic.